### PR TITLE
Delete old irrelevant AMDESE/linux branches from svsm-vtpm/linux?

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+# Ignore this commit, please see PR content
+
 Linux kernel
 ============
 


### PR DESCRIPTION
This repo, [svsm-vtpm/linux](https://github.com/svsm-vtpm/linux), is forked from [AMDESE/linux](https://github.com/AMDESE/linux). The fork brought over 60+ old branches with it. Can someone with admin access cull the old braches here? So far this repo only serves to host `svsm-vtpm-preview-guest` so maybe every other branch can be deleted.

This will make it more clear in github UI what the interesting content is, and simplify `git branch -a` output locally

Since issues are closed, I'm filing this as a bogus PR just to communicate with repo owners. Please disregard the commit.